### PR TITLE
Adding support for unique file name generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # codeceptjs-cucumber-json-reporter
+
 ## Description
 
 A [CodeceptJS](https://codecept.io) plugin to generate a cucumber json output file that can be consumed by [cucumber-html-reporter](https://www.npmjs.com/package/cucumber-html-reporter) or similar packages
 
 ---
+
 ## Requirements
+
 - CodeceptJS v3 or higher (tested with 3.0.5)
+
 ---
 
 ## Installation
+
 ```
 npm i codeceptjs-cucumber-json-reporter
 ```
 
 ---
+
 ## Configuration
 
 - Add plugin to your `codecept.conf.js`
+
 ```
 ...
 plugins: {
@@ -26,15 +33,18 @@ plugins: {
       attachScreenshots: true,     // true by default
       attachComments: true,        // true by default
       outputFile: 'file.json',     // cucumber_output.json by default
+      uniqueFileNames: false       // if true outputFile is ignored in favor of unique file names in the format of `cucumber_output_<UUID>.json`.  Useful for parallel test execution
     },
 }
 ...
 ```
 
 ---
+
 ## Usage
 
 When the plugin is installed and configured, run it as you would normally run any other CodeceptJS plugin:
+
 ```
 npx codeceptjs run --plugins cucumberReporter
 ```
@@ -44,17 +54,18 @@ The plugin parses the BDD feature file before the start of each feature and gene
 - Attach screenshots to your report by using `I.saveScreenshot` method in your steps
 - Attach comments to your report by using `I.say` method in your steps
 
-
 `cucumber_output.json` generated in your output folder on run completion.
 
 Some additional logging added when running `--verbose` to debug potential issues
 
 ---
+
 ## Html Report
 
 Use [cucumber-html-reporter](https://www.npmjs.com/package/cucumber-html-reporter) or other similar html reporters to generate your pretty html report passing the `cucumber_output.json` file as your source file.
 
 ---
+
 ## Limitations
+
 - CodeceptJS treats BDD steps as metasteps. Therefore if your step definition does not contain any helper methods it only fires bddStep events which are limited in what information we can extract.
-- Not tested with parallelized/multiple worker runs

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const defaultConfig = {
   attachScreenshots: true,
   attachComments: true,
   outputFile: 'cucumber_output.json',
+  uniqueFileNames: false
 };
 
 module.exports = function (config) {
@@ -96,8 +97,10 @@ module.exports = function (config) {
     // remove scenarios that weren't run
     // since we parse the whole feature file at start
     removeNotExecutedScenarios();
+    
+    const filename = config.uniqueFileNames ? `cucumber_output_${Math.floor(new Date().getTime() / 1000)}.json` : config.outputFile
 
-    fs.writeFile(path.join(global.output_dir, config.outputFile), JSON.stringify(allFeatures, null, 2), (err) => {
+    fs.writeFile(path.join(global.output_dir, filename), JSON.stringify(allFeatures, null, 2), (err) => {
       if (err) throw err;
     });
   });

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 
 const { event, output, recorder } = require('codeceptjs');
 const fs = require('fs');
-const base64Img = require('base64-img');
 const path = require('path');
 const _ = require('lodash');
 const btoa = require('btoa');
@@ -20,7 +19,7 @@ const defaultConfig = {
   attachScreenshots: true,
   attachComments: true,
   outputFile: 'cucumber_output.json',
-  uniqueFileNames: false
+  uniqueFileNames: false,
 };
 
 module.exports = function (config) {
@@ -97,8 +96,8 @@ module.exports = function (config) {
     // remove scenarios that weren't run
     // since we parse the whole feature file at start
     removeNotExecutedScenarios();
-    
-    const filename = config.uniqueFileNames ? `cucumber_output_${Math.floor(new Date().getTime() / 1000)}.json` : config.outputFile
+
+    const filename = config.uniqueFileNames ? `cucumber_output_${Math.floor(new Date().getTime() / 1000)}.json` : config.outputFile;
 
     fs.writeFile(path.join(global.output_dir, filename), JSON.stringify(allFeatures, null, 2), (err) => {
       if (err) throw err;
@@ -322,7 +321,7 @@ module.exports = function (config) {
     if (!config.attachScreenshots) return;
     const filename = path.join(global.output_dir, step.args[0]);
     try {
-      const convertedImg = base64Img.base64Sync(filename).split(',')[1];
+      const convertedImg = fs.readFileSync(filename, 'base64');
       const screenshot = {
         data: convertedImg,
         mime_type: 'image/png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codeceptjs-cucumber-json-reporter",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -161,15 +161,6 @@
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
-    "ajax-request": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/ajax-request/-/ajax-request-1.2.3.tgz",
-      "integrity": "sha1-mfy+wdbSeS+F+pSVNTMr0U9fN5A=",
-      "requires": {
-        "file-system": "^2.1.1",
-        "utils-extend": "^1.0.7"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -261,15 +252,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "base64-img": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/base64-img/-/base64-img-1.0.4.tgz",
-      "integrity": "sha1-PiLVXWx0okVT2EDSsbwSp9sHjTU=",
-      "requires": {
-        "ajax-request": "^1.2.0",
-        "file-system": "^2.1.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -801,23 +783,6 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
-      }
-    },
-    "file-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
-      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
-      "requires": {
-        "utils-extend": "^1.0.6"
-      }
-    },
-    "file-system": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
-      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
-      "requires": {
-        "file-match": "^1.0.1",
-        "utils-extend": "^1.0.4"
       }
     },
     "find-up": {
@@ -1722,11 +1687,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "utils-extend": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
-      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "eslint-plugin-import": "^2.22.1"
   },
   "dependencies": {
-    "base64-img": "^1.0.4",
     "btoa": "^1.2.1",
     "lodash": "^4.17.21"
   }


### PR DESCRIPTION
This PR addresses the need for unique file name generation when running CodeceptJS tests in parallel.

In the `cucumberJsonReporter` plugin configuration if `uniqueFileNames: true` is specified then results will be written to a file using this convention `cucumber_output_<unique_id>.json` and the value in  `outputFile` will be ignored.