### PR TITLE
Adding plugin functionality to work with CodeceptJS screenshotOnFail plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ module.exports = function (config) {
   config = Object.assign(defaultConfig, config);
   const plugin = {};
 
-  plugin.addScreenshot = (step, file_path) => {
-    addScreenshotToReport(step, file_path);
+  plugin.addScreenshot = (file_path) => {
+    addScreenshotToReport(file_path);
   };
 
   // Before suite starts, parse the feature file and set report feature position
@@ -73,7 +73,10 @@ module.exports = function (config) {
   });
 
   event.dispatcher.on(event.step.finished, (step) => {
-    if (step.helperMethod === 'saveScreenshot') addScreenshotToReport(step);
+    if (step.helperMethod === 'saveScreenshot') {
+      const filePath = path.join(global.output_dir, step.args[0]);
+      addScreenshotToReport(filePath);
+    }
   });
 
   event.dispatcher.on(event.step.comment, (step) => {
@@ -322,19 +325,18 @@ module.exports = function (config) {
     return bddCheck;
   }
 
-  function addScreenshotToReport(step, file_path) {
+  function addScreenshotToReport(file_path) {
     if (!config.attachScreenshots) return;
-    const filename = file_path || path.join(global.output_dir, step.args[0]);
     try {
-      const convertedImg = fs.readFileSync(filename, 'base64');
+      const convertedImg = fs.readFileSync(file_path, 'base64');
       const screenshot = {
         data: convertedImg,
         mime_type: 'image/png',
       };
-      output.log(`[CucumberJsonReporter] Adding ${filename} to:\n ${JSON.stringify(report.step)}`);
+      output.log(`[CucumberJsonReporter] Adding ${file_path} to:\n ${JSON.stringify(report.step)}`);
       report.step.embeddings.push(screenshot);
     } catch (error) {
-      output.log(`[CucumberJsonReporter] Couldn't add ${filename} to:\n ${JSON.stringify(report.step)}`);
+      output.log(`[CucumberJsonReporter] Couldn't add ${file_path} to:\n ${JSON.stringify(report.step)}`);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,11 @@ const defaultConfig = {
 module.exports = function (config) {
   // eslint-disable-next-line no-param-reassign
   config = Object.assign(defaultConfig, config);
+  const plugin = {};
+
+  plugin.addScreenshot = (step, file_path) => {
+    addScreenshotToReport(step, file_path);
+  };
 
   // Before suite starts, parse the feature file and set report feature position
   event.dispatcher.on(event.suite.before, (suite) => {
@@ -317,9 +322,9 @@ module.exports = function (config) {
     return bddCheck;
   }
 
-  function addScreenshotToReport(step) {
+  function addScreenshotToReport(step, file_path) {
     if (!config.attachScreenshots) return;
-    const filename = path.join(global.output_dir, step.args[0]);
+    const filename = file_path || path.join(global.output_dir, step.args[0]);
     try {
       const convertedImg = fs.readFileSync(filename, 'base64');
       const screenshot = {
@@ -342,4 +347,6 @@ module.exports = function (config) {
     output.log(`[CucumberJsonReporter] Adding comment "${step}" to:\n ${JSON.stringify(report.step)}`);
     report.step.embeddings.push(comment);
   }
+
+  return plugin;
 };


### PR DESCRIPTION
This PR will expose "addScreenshot" functionality via the CodeceptJS `plugin` pattern so that CodeceptJS `screenshotOnFail` plugin will be able to attach screenshots when it captures them.  

Once the PR is approved I will have to submit a subsequent PR to CodeceptJS in `lib/plugin/screenshotOnFail.js` just after this section

https://github.com/codeceptjs/CodeceptJS/blob/bfb8c0f9d20120adb2dc4bf87133aac48968e3eb/lib/plugin/screenshotOnFail.js#L106

```
const allureReporter = Container.plugins('allure');
if (allureReporter) {
  allureReporter.addAttachment('Last Seen Screenshot', fs.readFileSync(path.join(global.output_dir, fileName)), 'image/png');
}
```

That will look like this:
```
const cucumberReporter = Container.plugins('cucumberJsonReporter')
if(cucumberReporter){
  cucumberReporter.addScreenshot(test,test.artifacts.screenshot)
}
```

The result will be a report with embedded screenshots which are captured upon test failure.

<img width="1307" alt="Screen Shot 2021-04-26 at 2 42 17 PM" src="https://user-images.githubusercontent.com/11752901/116134260-b152c500-a69d-11eb-8ebf-8ae60d6849b7.png">
