### PR TITLE
Enhancing output to include actual example variable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ plugins: {
       attachScreenshots: true,     // true by default
       attachComments: true,        // true by default
       outputFile: 'file.json',     // cucumber_output.json by default
-      uniqueFileNames: false       // if true outputFile is ignored in favor of unique file names in the format of `cucumber_output_<UUID>.json`.  Useful for parallel test execution
+      uniqueFileNames: false,      // if true outputFile is ignored in favor of unique file names in the format of `cucumber_output_<UUID>.json`.  Useful for parallel test execution
+      includeExampleValues: false  // if true incorporate actual values from Examples table along with variable placeholder when writing steps to the report
     },
 }
 ...

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const defaultConfig = {
   attachComments: true,
   outputFile: 'cucumber_output.json',
   uniqueFileNames: false,
+  includeExampleValues: false,
 };
 
 module.exports = function (config) {
@@ -202,12 +203,18 @@ module.exports = function (config) {
       const rowCells = row.cells;
       const outlineExample = {};
 
+      let outlineScenario = _.cloneDeep(reportScenarioObject);
       for (let i = 0; i < rowCells.length; i++) {
         const headerCell = headerCells[i].value;
         const rowCell = rowCells[i].value;
         outlineExample[headerCell] = rowCell;
+        // append actual value to example variable place holders in steps
+        if (config.includeExampleValues) {
+          const re = new RegExp(headerCell, 'g');
+          outlineScenario = JSON.parse(JSON.stringify(outlineScenario).replace(re, `${headerCell}:${rowCell}`));
+        }
       }
-      const outlineScenario = _.cloneDeep(reportScenarioObject);
+
       outlineScenario.name += ` ${JSON.stringify(outlineExample)}`;
       splitScenarios.push(outlineScenario);
     });


### PR DESCRIPTION
For `Scenario Outlines`, the existing functionality only shows variable place holders in steps.  
![original](https://user-images.githubusercontent.com/11752901/118122263-992eb580-b3c0-11eb-9b72-d860a237ced0.png)


This change provides the ability to inject actual values from `Examples` into the report output when `includeExampleValues` is `true`
![Revised](https://user-images.githubusercontent.com/11752901/118122270-9cc23c80-b3c0-11eb-916e-bda5b6fee11c.png)

