### PR TITLE
Adding duration to report.step.result

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ plugins: {
       outputFile: 'file.json',     // cucumber_output.json by default
       uniqueFileNames: false,      // if true outputFile is ignored in favor of unique file names in the format of `cucumber_output_<UUID>.json`.  Useful for parallel test execution
       includeExampleValues: false  // if true incorporate actual values from Examples table along with variable placeholder when writing steps to the report
+      timeMultiplier: 1000000,     // Used when calculating duration of individual BDD steps.  Defaults to nanoseconds
+};
     },
 }
 ...

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const defaultConfig = {
   outputFile: 'cucumber_output.json',
   uniqueFileNames: false,
   includeExampleValues: false,
+  timeMultiplier: 1000000, // nanoseconds
 };
 
 module.exports = function (config) {
@@ -105,7 +106,7 @@ module.exports = function (config) {
       if (report && report.step) {
         report.step.end_time = Date.now();
         // calculate the duration in nanoseconds for cucumber-html-reporter
-        report.step.result.duration = (report.step.end_time - report.step.start_time) * 1000000;
+        report.step.result.duration = (report.step.end_time - report.step.start_time) * config.timeMultiplier;
       }
     });
   });
@@ -333,7 +334,7 @@ module.exports = function (config) {
     return rootStep;
   }
 
-  // Checks if step is actually BDD
+  // Checks if step is actually BDDconfig.includeExampleValues
   // Before-After Hooks aren't BDD and we want to exclude those from reporting pass/fail
   function isBDD(step) {
     const metaStep = getRootMetaStep(step);

--- a/index.js
+++ b/index.js
@@ -74,6 +74,9 @@ module.exports = function (config) {
   });
 
   event.dispatcher.on(event.step.finished, (step) => {
+    if (!isBDD(step)) return;
+    // calculate the duration in nanoseconds for cucumber-html-reporter
+    report.step.result.duration = (step.endTime - step.startTime) * 1000000;
     if (step.helperMethod === 'saveScreenshot') {
       const filePath = path.join(global.output_dir, step.args[0]);
       addScreenshotToReport(filePath);

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ module.exports = function (config) {
     recorder.add('Set step end time and duration', async () => {
       if (report && report.step) {
         report.step.end_time = Date.now();
-        // calculate the duration in nanoseconds for cucumber-html-reporter
+        // calculate the duration based on config timeMultiplier for reporting tools
         report.step.result.duration = (report.step.end_time - report.step.start_time) * config.timeMultiplier;
       }
     });
@@ -334,7 +334,7 @@ module.exports = function (config) {
     return rootStep;
   }
 
-  // Checks if step is actually BDDconfig.includeExampleValues
+  // Checks if step is actually BDD
   // Before-After Hooks aren't BDD and we want to exclude those from reporting pass/fail
   function isBDD(step) {
     const metaStep = getRootMetaStep(step);


### PR DESCRIPTION
`cucumber-html-reporter` is expecting step duration to be included as part of `step.result`.  This change will pass along the value so that we can get duration of steps as part of the HTML report.

Before:
<img width="1152" alt="Screen Shot 2021-06-30 at 12 36 39 PM" src="https://user-images.githubusercontent.com/11752901/123999001-0c57af80-d9a0-11eb-87f5-7f70bf8d76d8.png">

After:
<img width="1152" alt="Screen Shot 2021-06-30 at 12 38 54 PM" src="https://user-images.githubusercontent.com/11752901/123999305-5f316700-d9a0-11eb-953d-d9431eeb2964.png">

