### PR TITLE
Capture descriptions written at the Scenario / Scenario Outline Level

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,6 +170,7 @@ module.exports = function (config) {
         id: codeceptScenarioObject.name.replace(/ /g, '_').replace(/,/g, ''),
         keyword: codeceptScenarioObject.keyword,
         name: codeceptScenarioObject.name,
+        description: codeceptScenarioObject.description,
         type: 'scenario',
         line: codeceptScenarioObject.location.line,
         tags: [],


### PR DESCRIPTION
Gherkin syntax supports adding descriptions below Scenario / Scenario Outline declarations and Codecept captures this information for use in reporters.  This change will incorporate these descriptions in the generated json.

<img width="1183" alt="Screen Shot 2021-09-29 at 9 08 40 AM" src="https://user-images.githubusercontent.com/11752901/135275162-9c908ad6-620d-465e-9562-de27f96273ec.png">


