### PR TITLE
Fix Scenario Outline containing header cell string

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,8 +225,8 @@ module.exports = function (config) {
           outlineExample[headerCell] = rowCell;
           // append actual value to example variable place holders in steps
           if (config.includeExampleValues) {
-            const re = new RegExp(headerCell, 'g');
-            outlineScenario = JSON.parse(JSON.stringify(outlineScenario).replace(re, `${headerCell}:${rowCell}`));
+            const re = new RegExp(`<${headerCell}>`, 'g');
+            outlineScenario = JSON.parse(JSON.stringify(outlineScenario).replace(re, `<${headerCell}:${rowCell}>`));
           }
         }
 


### PR DESCRIPTION
When `Scenario Outline` name or step contains a string matching a table header cell, codecept execution fails to find the example scenario.

```
    Scenario Outline: I update calendar day
        Given  I am logged in to calendar
        When I add event on day: <day>
        Then The event shows in reminders

        Examples:
            | day |
            |  2  |
```

This happens when `includeExampleValues: true` . 
The is because the plugin does a global replace of all header cell strings.

Fixing this issue by updating the regex to only replace strings enclosed with `< >` 