### PR TITLE
Fix for background usage in codecept v3.4.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ module.exports = function (config) {
 
     // get all scenarios
     feature.children.forEach((codeceptObject) => {
-      const codeceptScenarioObject = codeceptObject.scenario || codeceptObject;
+      const codeceptScenarioObject = codeceptObject.scenario || codeceptObject.background || codeceptObject;
       const reportScenarioObject = {
         executed: false,
         id: codeceptScenarioObject.name.replace(/ /g, '_').replace(/,/g, ''),


### PR DESCRIPTION
When `Background` is used in a `.feature` file the following error is being thrown by the reporter

```
Error processing suite.before event:
TypeError: Cannot read properties of undefined (reading 'replace')
    at /Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs-cucumber-json-reporter/index.js:175:41
    at Array.forEach (<anonymous>)
    at buildReportScenarios (/Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs-cucumber-json-reporter/index.js:169:22)
    at buildReportFeature (/Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs-cucumber-json-reporter/index.js:159:23)
    at EventEmitter.<anonymous> (/Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs-cucumber-json-reporter/index.js:38:21)
    at EventEmitter.emit (node:events:539:35)
    at Object.emit (/Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs/lib/event.js:145:28)
    at /Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs/lib/scenario.js:189:11
    at injectHook (/Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs/lib/scenario.js:10:5)
    at module.exports.suiteSetup (/Users/jim.davis/repos/sandbox-codecept/node_modules/codeceptjs/lib/scenario.js:187:10)
TypeError: Cannot read properties of null (reading 'elements')
```

Looks like in CodeceptJS 3.4.1 the shape of the `Background` object has also changed

`3.3.7`
```
{
  type: 'Background',
  location: { line: 3, column: 3 },
  keyword: 'Background',
  name: 'Setup',
  description: undefined,
  steps: [
    {
      type: 'Step',
      location: [Object],
      keyword: 'Given ',
      text: 'something happens',
      argument: undefined
    }
  ]
}
```

`3.4.1`
```
{
  background: {
    id: 'b55d2dfc-c648-44d9-ac84-e0180246308f',
    location: { line: 3, column: 3 },
    keyword: 'Background',
    name: 'Setup',
    description: '',
    steps: [ [Object] ]
  }
}
```