### PR TITLE
Save screenshot for metaSteps also

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ module.exports = function (config) {
   });
 
   event.dispatcher.on(event.step.finished, (step) => {
-    if (step.helperMethod === 'saveScreenshot') {
-      const filePath = path.join(global.output_dir, step.args[0]);
+    if (getRootMetaStep(step).helperMethod === 'saveScreenshot') {
+      const filePath = path.join(global.output_dir, getRootMetaStep(step).args[0]);
       addScreenshotToReport(filePath);
     }
   });


### PR DESCRIPTION
Update after step hook to check metaStep for saveScreenshot call. 
We want to save the screenshot in the report even if its part of a metaStep.

This can happen if you overload saveScreenshot in custom_steps.

use case:
```
// Overload saveScreenshot to use additional playwright options
async saveScreenshot(name, options) {
  
  const outputPath = path.join(output_dir, name);

  // set default options
  const defaultOptions = {
    path: outputPath,
    fullPage: true,
    animations: 'disabled',
    quality: 100,
    type: 'jpeg'
  }

  // merge default options with user options
  const mergedOptions = Object.assign(defaultOptions, options);

  this.usePlaywrightTo('Save a screenshot', async ({ page }) => {
    await page.screenshot(mergedOptions);
  });
},
```